### PR TITLE
Allowed Accessing Unsafe Values from bound Asbind Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Each **exported function** has the properties:
   - If you would like to disable type caching (speculative execution) for a particular function, you can do: `asBindInstance.exports.myFunction.shouldCacheTypes = false;`. Or set to true, to re-enable type caching.
 - `unsafeReturnValue`
   - By default, all values (in particular [TypedArrays](https://www.assemblyscript.org/stdlib/typedarray.html#typedarray)) will be copied out of Wasm Memory, instead of giving direct read/write access. If you would like to use a view of the returned memory, you can do: `asBindInstance.exports.myFunction.unsafeReturnValue = true;`. For More context, please see the [AssemblyScript loader documentation](https://www.assemblyscript.org/loader.html#module-instance-utility) on array views.
+  - After settings this flag on a function, it will then return it's values wrapped in an object, like so: `{ptr: /* The pointer or index in wasm memory the view is reffering to */, value: /* The returned value (TypedArray) that is backed directly by Wasm Memory */}`
 
 ##### unboundExports
 

--- a/README.md
+++ b/README.md
@@ -235,7 +235,12 @@ An AsBindInstance is vaugley similar to a [WebAssembly instance](https://develop
 
 Similar to to [WebAssembly.Instance.prototype.exports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance/exports), this is an object containing all of the exported fields from the WebAssembly module. However, **exported functions** are bound / wrapped in which they will handle passing the supported high-level data types to the exported AssemblyScript function.
 
-Each **exported function** has the property: `shouldCacheTypes`. If you would like to disable type caching (speculative execution) for a particular function, you can do: `asBindInstance.exports.myFunction.shouldCacheTypes = false;`. Or set to true, to re-enable type caching.
+Each **exported function** has the properties:
+
+- `shouldCacheTypes`
+  - If you would like to disable type caching (speculative execution) for a particular function, you can do: `asBindInstance.exports.myFunction.shouldCacheTypes = false;`. Or set to true, to re-enable type caching.
+- `unsafeReturnValue`
+  - By default, all values (in particular [TypedArrays](https://www.assemblyscript.org/stdlib/typedarray.html#typedarray)) will be copied out of Wasm Memory, instead of giving direct read/write access. If you would like to use a view of the returned memory, you can do: `asBindInstance.exports.myFunction.unsafeReturnValue = true;`. For More context, please see the [AssemblyScript loader documentation](https://www.assemblyscript.org/loader.html#module-instance-utility) on array views.
 
 ##### unboundExports
 
@@ -254,6 +259,14 @@ Calling this method will (re-)enable type caching (speculative execution) for AL
 ##### disableExportFunctionTypeCaching
 
 Calling this method will disable type caching (speculative execution) for ALL exported functions on the AsBindInstance.
+
+##### enableExportFunctionUnsafeReturnValue
+
+Calling this method will (re-)enable unsafe return types for ALL exported functions on the AsBindInstance.
+
+##### disableExportFunctionUnsafeReturnValue
+
+Calling this method will disable unsafe return types for ALL exported functions on the AsBindInstance.
 
 ##### enableImportFunctionTypeCaching
 

--- a/lib/asbind-instance/asbind-instance.js
+++ b/lib/asbind-instance/asbind-instance.js
@@ -122,6 +122,18 @@ export default class AsbindInstance {
     });
   }
 
+  enableExportFunctionUnsafeReturnValue() {
+    Object.keys(this.exports).forEach(exportKey => {
+      this.exports[exportKey].unsafeReturnValue = true;
+    });
+  }
+
+  disableExportFunctionUnsafeReturnValue() {
+    Object.keys(this.exports).forEach(exportKey => {
+      this.exports[exportKey].unsafeReturnValue = false;
+    });
+  }
+
   enableImportFunctionTypeCaching() {
     // Need to traverse the importObject and bind all import functions
     traverseObjectAndRunCallbackForFunctions(

--- a/lib/asbind-instance/bind-function.js
+++ b/lib/asbind-instance/bind-function.js
@@ -226,7 +226,10 @@ export function bindExportFunction(asbindInstance, exportFunctionKey) {
       }
 
       if (supportedType) {
-        if (functionThis.unsafeReturnValue) {
+        if (
+          functionThis.unsafeReturnValue &&
+          supportedType.getUnsafeValueFromRef
+        ) {
           response = supportedType.getUnsafeValueFromRef(
             exports,
             exportFunctionResponse

--- a/lib/asbind-instance/bind-function.js
+++ b/lib/asbind-instance/bind-function.js
@@ -226,10 +226,17 @@ export function bindExportFunction(asbindInstance, exportFunctionKey) {
       }
 
       if (supportedType) {
-        response = supportedType.getValueFromRef(
-          exports,
-          exportFunctionResponse
-        );
+        if (functionThis.unsafeReturnValue) {
+          response = supportedType.getUnsafeValueFromRef(
+            exports,
+            exportFunctionResponse
+          );
+        } else {
+          response = supportedType.getValueFromRef(
+            exports,
+            exportFunctionResponse
+          );
+        }
       } else if (typeof exportFunctionResponse === "number") {
         response = exportFunctionResponse;
         if (functionThis.shouldCacheTypes) {

--- a/lib/asbind-instance/bind-function.js
+++ b/lib/asbind-instance/bind-function.js
@@ -253,6 +253,7 @@ export function bindExportFunction(asbindInstance, exportFunctionKey) {
 
   // Initialize the state of our function
   boundExport.shouldCacheTypes = true;
+  boundExport.unsafeReturnValue = false;
   boundExport.cachedArgTypes = [];
   boundExport.cachedReturnTypes = [];
 

--- a/lib/asbind-instance/supported-ref-types.js
+++ b/lib/asbind-instance/supported-ref-types.js
@@ -26,7 +26,10 @@ const SUPPORTED_REF_TYPES = {
       );
     },
     getValueFromRef: (wasmExports, responseRef) => {
-      return wasmExports.__getInt8Array(responseRef).slice();
+      return wasmExports.__getInt8Array(responseRef);
+    },
+    getUnsafeValueFromRef: (wasmExports, responseRef) => {
+      return wasmExports.__getInt8ArrayView(responseRef);
     }
   },
   UINT8ARRAY: {
@@ -42,7 +45,10 @@ const SUPPORTED_REF_TYPES = {
       );
     },
     getValueFromRef: (wasmExports, responseRef) => {
-      return wasmExports.__getUint8Array(responseRef).slice();
+      return wasmExports.__getUint8Array(responseRef);
+    },
+    getUnsafeValueFromRef: (wasmExports, responseRef) => {
+      return wasmExports.__getUint8ArrayView(responseRef);
     }
   },
   INT16ARRAY: {
@@ -58,7 +64,10 @@ const SUPPORTED_REF_TYPES = {
       );
     },
     getValueFromRef: (wasmExports, responseRef) => {
-      return wasmExports.__getInt16Array(responseRef).slice();
+      return wasmExports.__getInt16Array(responseRef);
+    },
+    getUnsafeValueFromRef: (wasmExports, responseRef) => {
+      return wasmExports.__getInt16ArrayView(responseRef);
     }
   },
   UINT16ARRAY: {
@@ -74,7 +83,10 @@ const SUPPORTED_REF_TYPES = {
       );
     },
     getValueFromRef: (wasmExports, responseRef) => {
-      return wasmExports.__getUint16Array(responseRef).slice();
+      return wasmExports.__getUint16Array(responseRef);
+    },
+    getUnsafeValueFromRef: (wasmExports, responseRef) => {
+      return wasmExports.__getUint16ArrayView(responseRef);
     }
   },
   INT32ARRAY: {
@@ -90,7 +102,10 @@ const SUPPORTED_REF_TYPES = {
       );
     },
     getValueFromRef: (wasmExports, responseRef) => {
-      return wasmExports.__getInt32Array(responseRef).slice();
+      return wasmExports.__getInt32Array(responseRef);
+    },
+    getUnsafeValueFromRef: (wasmExports, responseRef) => {
+      return wasmExports.__getInt32ArrayView(responseRef);
     }
   },
   UINT32ARRAY: {
@@ -106,7 +121,10 @@ const SUPPORTED_REF_TYPES = {
       );
     },
     getValueFromRef: (wasmExports, responseRef) => {
-      return wasmExports.__getUint32Array(responseRef).slice();
+      return wasmExports.__getUint32Array(responseRef);
+    },
+    getUnsafeValueFromRef: (wasmExports, responseRef) => {
+      return wasmExports.__getUint32ArrayView(responseRef);
     }
   },
   FLOAT32ARRAY: {
@@ -125,7 +143,10 @@ const SUPPORTED_REF_TYPES = {
       );
     },
     getValueFromRef: (wasmExports, responseRef) => {
-      return wasmExports.__getFloat32Array(responseRef).slice();
+      return wasmExports.__getFloat32Array(responseRef);
+    },
+    getUnsafeValueFromRef: (wasmExports, responseRef) => {
+      return wasmExports.__getFloat32ArrayView(responseRef);
     }
   },
   FLOAT64ARRAY: {
@@ -144,7 +165,10 @@ const SUPPORTED_REF_TYPES = {
       );
     },
     getValueFromRef: (wasmExports, responseRef) => {
-      return wasmExports.__getFloat64Array(responseRef).slice();
+      return wasmExports.__getFloat64Array(responseRef);
+    },
+    getUnsafeValueFromRef: (wasmExports, responseRef) => {
+      return wasmExports.__getFloat64ArrayView(responseRef);
     }
   }
 };

--- a/lib/asbind-instance/supported-ref-types.js
+++ b/lib/asbind-instance/supported-ref-types.js
@@ -1,3 +1,10 @@
+const getUnsafeResponse = (value, ptr) => {
+  return {
+    ptr: ptr,
+    value: value
+  };
+};
+
 const SUPPORTED_REF_TYPES = {
   STRING: {
     isTypeFromArgument: arg => {
@@ -29,7 +36,10 @@ const SUPPORTED_REF_TYPES = {
       return wasmExports.__getInt8Array(responseRef);
     },
     getUnsafeValueFromRef: (wasmExports, responseRef) => {
-      return wasmExports.__getInt8ArrayView(responseRef);
+      return getUnsafeResponse(
+        wasmExports.__getInt8ArrayView(responseRef),
+        responseRef
+      );
     }
   },
   UINT8ARRAY: {
@@ -48,7 +58,10 @@ const SUPPORTED_REF_TYPES = {
       return wasmExports.__getUint8Array(responseRef);
     },
     getUnsafeValueFromRef: (wasmExports, responseRef) => {
-      return wasmExports.__getUint8ArrayView(responseRef);
+      return getUnsafeResponse(
+        wasmExports.__getUint8ArrayView(responseRef),
+        responseRef
+      );
     }
   },
   INT16ARRAY: {
@@ -67,7 +80,10 @@ const SUPPORTED_REF_TYPES = {
       return wasmExports.__getInt16Array(responseRef);
     },
     getUnsafeValueFromRef: (wasmExports, responseRef) => {
-      return wasmExports.__getInt16ArrayView(responseRef);
+      return getUnsafeResponse(
+        wasmExports.__getInt16ArrayView(responseRef),
+        responseRef
+      );
     }
   },
   UINT16ARRAY: {
@@ -86,7 +102,10 @@ const SUPPORTED_REF_TYPES = {
       return wasmExports.__getUint16Array(responseRef);
     },
     getUnsafeValueFromRef: (wasmExports, responseRef) => {
-      return wasmExports.__getUint16ArrayView(responseRef);
+      return getUnsafeResponse(
+        wasmExports.__getUint16ArrayView(responseRef),
+        responseRef
+      );
     }
   },
   INT32ARRAY: {
@@ -105,7 +124,10 @@ const SUPPORTED_REF_TYPES = {
       return wasmExports.__getInt32Array(responseRef);
     },
     getUnsafeValueFromRef: (wasmExports, responseRef) => {
-      return wasmExports.__getInt32ArrayView(responseRef);
+      return getUnsafeResponse(
+        wasmExports.__getInt32ArrayView(responseRef),
+        responseRef
+      );
     }
   },
   UINT32ARRAY: {
@@ -124,7 +146,10 @@ const SUPPORTED_REF_TYPES = {
       return wasmExports.__getUint32Array(responseRef);
     },
     getUnsafeValueFromRef: (wasmExports, responseRef) => {
-      return wasmExports.__getUint32ArrayView(responseRef);
+      return getUnsafeResponse(
+        wasmExports.__getUint32ArrayView(responseRef),
+        responseRef
+      );
     }
   },
   FLOAT32ARRAY: {
@@ -146,7 +171,10 @@ const SUPPORTED_REF_TYPES = {
       return wasmExports.__getFloat32Array(responseRef);
     },
     getUnsafeValueFromRef: (wasmExports, responseRef) => {
-      return wasmExports.__getFloat32ArrayView(responseRef);
+      return getUnsafeResponse(
+        wasmExports.__getFloat32ArrayView(responseRef),
+        responseRef
+      );
     }
   },
   FLOAT64ARRAY: {
@@ -168,7 +196,10 @@ const SUPPORTED_REF_TYPES = {
       return wasmExports.__getFloat64Array(responseRef);
     },
     getUnsafeValueFromRef: (wasmExports, responseRef) => {
-      return wasmExports.__getFloat64ArrayView(responseRef);
+      return getUnsafeResponse(
+        wasmExports.__getFloat64ArrayView(responseRef),
+        responseRef
+      );
     }
   }
 };

--- a/test/test.js
+++ b/test/test.js
@@ -674,19 +674,29 @@ describe("asbind", () => {
 
         assert.equal(
           asbindInstance.exports[exportName].unsafeReturnValue,
-          undefined
+          false
         );
+
+        let randomValue;
+        let array;
+        let arrayMapResponse;
+
+        randomValue = Math.floor(Math.random() * 10) + 1;
+        array = global[typedArrayKey].from([randomValue]);
+        arrayMapResponse = asbindInstance.exports[exportName](array);
+
+        // Check to make sure it returns an arrary
+        assert(arrayMapResponse.length > 0);
 
         asbindInstance.exports[exportName].unsafeReturnValue = true;
 
-        const randomValue = Math.floor(Math.random() * 10) + 1;
-        const array = global[typedArrayKey].from([randomValue]);
-        const arrayMapResponse = asbindInstance.exports[exportName](array);
+        randomValue = Math.floor(Math.random() * 10) + 1;
+        array = global[typedArrayKey].from([randomValue]);
+        arrayMapResponse = asbindInstance.exports[exportName](array);
 
-        console.log(arrayMapResponse);
-
-        // Ensure it has the correct values
-        assert.equal(testImportCalledWith[0][0], randomValue);
+        // Assert it now returns a pointer and a value
+        assert(arrayMapResponse.ptr !== undefined);
+        assert(arrayMapResponse.value !== undefined);
       });
     });
   });

--- a/test/test.js
+++ b/test/test.js
@@ -658,6 +658,12 @@ describe("asbind", () => {
       );
     });
 
+    it("should not break strings", () => {
+      asbindInstance.exports.helloWorld.unsafeReturnValue = true;
+      const response = asbindInstance.exports.helloWorld("asbind");
+      assert.equal(response, "Hello asbind!");
+    });
+
     // TypedArrays
     [
       "Int8Array",


### PR DESCRIPTION
closes #47 
closes #9 

This allows setting an `unsafeReturnValue` flag on functions, that will then return direct view on memory, instead of copying them out of memory. Please see the issues for context.

![Screenshot from 2020-10-09 15-40-53](https://user-images.githubusercontent.com/1448289/95637148-e2431380-0a45-11eb-98d2-6d02f7a6d581.png)
