### PR TITLE
Added types to package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/as-bind.cjs.js",
   "module": "dist/as-bind.esm.js",
   "iife": "dist/as-bind.iife.js",
+  "types": "dist/as-bind.d.ts",
   "scripts": {
     "build": "run-s lib:wasm:build lib:js:build",
     "dev": "run-p lib:watch lib:test:watch",


### PR DESCRIPTION
closes #49 

Just added the types key to the package json for our `as-bind.d.ts` file, as referenced in the typescript docs: https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html