### PR TITLE
Mitigate as bind typings

### DIFF
--- a/lib/as-bind.d.ts
+++ b/lib/as-bind.d.ts
@@ -1,13 +1,2 @@
-import { instantiate, instantiateSync } from "@assemblyscript/loader";
-
-export interface AsBind {
-  // General asbind versionn
-  version: number;
-
-  // Our APIs
-  instantiate: typeof instantiate;
-
-  instantiateSync: typeof instantiateSync;
-}
-
-export type AsBindLib = AsBind;
+// We plan to port AsBind to TypeScript: https://github.com/torch2424/as-bind/issues/56
+export var AsBind: any;


### PR DESCRIPTION
closes #52 
relates to #56 

This just mitigates the broken typings by just following: https://www.stevefenton.co.uk/2013/01/complex-typescript-definitions-made-easy/

As mentioned in #56 We should probably just port the library to TypeScript whenever we find the time :smile: 

[WIP as #55 should be merged first]