### PR TITLE
Update README for type embeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,13 @@ Isomorphic library to handle passing high-level data structures between Assembly
 
 ## Features
 
-- The library is Isomorphic. Meaning it supports both the Browser, and Node! And has ESM, CommonJS, and IIFE bundles! 🌐
+- The library is isomorphic. Meaning it supports both the Browser, and Node! And has ESM, AMD, CommonJS, and IIFE bundles! 🌐
 - Wraps around the [AssemblyScript Loader](https://github.com/AssemblyScript/assemblyscript/tree/master/lib/loader). The loader handles all the heavy-lifting of passing data into WebAssembly linear memory. 💪
 - Wraps around imported JavaScript functions, and exported AssemblyScript functions of the AssemblyScript Wasm Module. This allows high-level data types to be passed directly to exported AssemblyScript functions! 🤯
-- The library works at runtime, so no generated code that you have to maintain and make it play nicely in your environment. 🏃
-- Maintains great performance (relative to generating the corresponding JavaScript code), by using [Speculative Execution](https://en.wikipedia.org/wiki/Speculative_execution), and caching types passed between functions. 🤔
+- Moves a lot of work to compile-time using [AssemblyScript Transforms](https://www.assemblyscript.org/transforms.html#transforms) and completely avoids module-specific “glue code”. 🏃
 - Installable from package managers (npm), with a modern JavaScript API syntax. 📦
-- The library is [< 5KB (minified and gzip'd)](https://bundlephobia.com/result?p=as-bind) and tree-shakeable! 🌲
-- This library is currently (as of January, 2020) the [wasm-bindgen](https://github.com/rustwasm/wasm-bindgen) in the Rust/Wasm ecosystem, for AssemblyScript. 😀
+- The library is [< 4KB (minified and gzip'd)](https://bundlephobia.com/result?p=as-bind), _including_ the AssemblyScript Loader ! 🌲
+- This library is currently (as of January, 2020) the [wasm-bindgen](https://github.com/rustwasm/wasm-bindgen) of AssemblyScript. 😀
 
 ## Installation
 
@@ -52,15 +51,14 @@ You can install as-bind in your project by running the following:
 
 **1. Compiling your Assemblyscript**
 
-To enable as-bind for your AssemblyScript Wasm modules, add the as-bind entrypoint when compiling your module:
+To enable as-bind for your AssemblyScript Wasm modules, add the as-bind transform when compiling your module:
 
-`asc ./node_modules/as-bind/lib/assembly/as-bind.ts your-entryfile.ts --runtime incremental --exportRuntime [...other cli options...]`
+`asc your-entryfile.ts --exportRuntime --transform as-bind [...other cli options...]`
 
 The things to notice are:
 
-- `./node_modules/as-bind/lib/assembly/as-bind.ts` - This is the as-bind entryfile, used for exporting IDs of AssemblyScript classes so we can use them for instantiating new classes
-- `--runtime incremental` - This specifies that we are using the incremental runtime / garbage collection option (The AssemblyScript default). However, [all the runtime options](https://www.assemblyscript.org/garbage-collection.html) are supported (incremental, minimal, and stub).
-- `--exportRuntime` - This allows us to use the [AssemblyScript Garbage Collection functions added in 0.18.x](https://www.assemblyscript.org/garbage-collection.html)
+- `--transform as-bind` - This is the as-bind transform that runs at compile time. It embeds all the required type information into the WebAssembly Module.
+- `--exportRuntime` - This is required for the AssemblyScript Loader to work properly. It [exposes functions](https://www.assemblyscript.org/garbage-collection.html#runtime-interface) on the module to allocate memory from JavaScript.
 
 For **optional testing purposes** , let's export an example function we can try in `your-entryfile.ts`:
 
@@ -167,22 +165,9 @@ asyncTask();
 
 ## Supported Data Types
 
-**TL;DR:** Currently Numbers, Strings, Typed Arrays, and common Array<T> types are supported. Returning a high-level data type from an imported JavaScript function, and better AssemblyScript Class support will be coming later. For more detailed type support information, please see the [`lib/asbind-instance/supported-ref-types.js`](./lib/asbind-instance/supported-ref-types.js) and [`test/assembly/test.ts`](./test/assembly/test.ts).
+All primitive types, ie. Numbers (`u8`, `f32`, ...) , Strings, Typed Arrays (`Uint8Array`, `Float32Array`, ...) are supported. All of those types can also be used with `Array<T>`.
 
-<!-- Generated from: https://www.tablesgenerator.com/markdown_tables# -->
-
-| Function Direction & AssemblyScript Type                                                                | Exported AssemblyScript Function Parameters | Exported AssemblyScript Function Return | Imported JavaScript Function Paramters | Imported JavaScript Function Return |
-| ------------------------------------------------------------------------------------------------------- | ------------------------------------------- | --------------------------------------- | -------------------------------------- | ----------------------------------- |
-| [Number (32-bit Integers and 32-bit / 64-bit Floats)](https://www.assemblyscript.org/types.html#types)  | ✔️                                          | ✔️                                      | ✔️                                     | ✔️                                  |
-| [Strings](https://www.assemblyscript.org/stdlib/string.html#string)                                     | ✔️                                          | ✔️                                      | ✔️                                     | ❌                                  |
-| [TypedArray](https://www.assemblyscript.org/stdlib/typedarray.html#typedarray)                          | ✔️                                          | ✔️                                      | ✔️                                     | ❌                                  |
-| [Array<T> (Numbers, strings, booleans, etc...)](https://www.assemblyscript.org/stdlib/array.html#array) | ✔️                                          | ✔️                                      | ✔️                                     | ❌                                  |
-
-## Supported AssemblyScript Runtime Variants
-
-as-bind only supports AssemblyScript modules compiled with the `--runtime full` (default), and `--runtime stub` flags. These should be the only supported modes, because these runtime variants specify that you would like types / objects to be created externally as well as internally. Other runtime variants would mean that you DO NOT want anything externally created for your wasm module.
-
-Please see the [AssemblyScript Docs on runtime variants](https://docs.assemblyscript.org/details/runtime) for more information.
+Custom classes are currently not support, but planned.
 
 ## Reference API
 
@@ -192,33 +177,13 @@ The default exported ESM class of `as-bind`, also available as `import { AsBind 
 
 #### Class Properties
 
-The `AsBind` class is meant to vaugely act as the [WebAssembly](https://developer.mozilla.org/en-US/docs/WebAssembly) Object exposed to JavaScript environments.
+The `AsBind` class is meant to _vaguely_ act as the [WebAssembly](https://developer.mozilla.org/en-US/docs/WebAssembly) Object exposed to JavaScript environments.
 
 ##### version
 
 `AsBind.version: string`
 
 Value that is the current version of your imported AsBind.
-
-##### RETURN_TYPES
-
-`AsBind.RETURN_TYPES`
-
-Constants (represented as JSON) of the supported return types on bound export functions. This is useful for forcing the return type on [bound export functions](#exports).
-
-For example, this could be used like:
-
-```typescript
-// Force our return type to our expected string
-asBindInstance.exports.myExportedFunctionThatReturnsAString.returnType =
-  AsBind.RETURN_TYPES.STRING;
-const myString = asBindInstance.exports.myExportedFunctionThatReturnsAString();
-
-// Force our return type to return a number (The pointer to the string)
-asBindInstance.exports.myExportedFunctionThatReturnsAString.returnType =
-  AsBind.RETURN_TYPES.NUMBER;
-const myNumber = asBindInstance.exports.myExportedFunctionThatReturnsAString();
-```
 
 ##### instantiate
 
@@ -256,55 +221,19 @@ This is a synchronous version of `AsBind.instantiate`. This does not accept a pr
 
 #### Instance Properties
 
-An AsBindInstance is vaugley similar to a [WebAssembly instance](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance).
+An AsBindInstance is vaguely similar to a [WebAssembly instance](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance).
+
+##### loadedModule
+
+The raw, untouched instance of the WebAssembly Module.
 
 ##### exports
 
 Similar to to [WebAssembly.Instance.prototype.exports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance/exports), this is an object containing all of the exported fields from the WebAssembly module. However, **exported functions** are bound / wrapped in which they will handle passing the supported high-level data types to the exported AssemblyScript function.
 
-Each **exported function** has the properties:
-
-- `shouldCacheTypes`
-  - If you would like to disable type caching (speculative execution) for a particular function, you can do: `asBindInstance.exports.myFunction.shouldCacheTypes = false;`. Or set to true, to re-enable type caching.
-- `returnType`
-  - (Reccomended for production usage) Set this value on a bound export function, to force it's return type. This should be set to a constant found on: [`AsBind.RETURN_TYPES`](#return_types). Defaults to `null`.
-- `unsafeReturnValue`
-  - By default, all values (in particular [TypedArrays](https://www.assemblyscript.org/stdlib/typedarray.html#typedarray)) will be copied out of Wasm Memory, instead of giving direct read/write access. If you would like to use a view of the returned memory, you can do: `asBindInstance.exports.myFunction.unsafeReturnValue = true;`. For More context, please see the [AssemblyScript loader documentation](https://www.assemblyscript.org/loader.html#module-instance-utility) on array views.
-  - After settings this flag on a function, it will then return it's values wrapped in an object, like so: `{ptr: /* The pointer or index in wasm memory the view is reffering to */, value: /* The returned value (TypedArray) that is backed directly by Wasm Memory */}`
-
-##### unboundExports
-
-This is essentially the same as the [WebAssembly.Instance.prototype.exports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance/exports), this is an object containing all of the exported fields from the WebAssembly module. These are not bound / wrapped, so you can access the original exported functions.
-
 ##### importObject
 
-Similar to to [WebAssembly.instantiateStreaming() importObject](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming), This is the original passed importObject on instantiation, after the **importObject functions** are bound / wrapped by as-bind.
-
-Each wrapped **importObject function** has the property: `shouldCacheTypes`. If you would like to disable type caching (speculative execution) for a particular function, you can do: `asBindInstance.importObject.myFunction.shouldCacheTypes = false;`. Or set to true, to re-enable type caching.
-
-##### enableExportFunctionTypeCaching
-
-Calling this method will (re-)enable type caching (speculative execution) for ALL exported functions on the AsBindInstance.
-
-##### disableExportFunctionTypeCaching
-
-Calling this method will disable type caching (speculative execution) for ALL exported functions on the AsBindInstance.
-
-##### enableExportFunctionUnsafeReturnValue
-
-Calling this method will (re-)enable unsafe return types for ALL exported functions on the AsBindInstance.
-
-##### disableExportFunctionUnsafeReturnValue
-
-Calling this method will disable unsafe return types for ALL exported functions on the AsBindInstance.
-
-##### enableImportFunctionTypeCaching
-
-Calling this method will (re-)enable type caching (speculative execution) for ALL importObject functions on the AsBindInstance.
-
-##### disableImportFunctionTypeCaching
-
-Calling this method will disable type caching (speculative execution) for ALL importObject functions on the AsBindInstance.
+Similar to to [WebAssembly.instantiateStreaming() importObject](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming), this is the augmented `importObject`. It’s based on the original that was passed to one of the instantiation functions, but functions have been wrapped to handle high-level types.
 
 ## Motivation
 
@@ -314,27 +243,15 @@ This library was inspired by several chats I had with some awesome buddies of mi
 
 - While I was building [WasmByExample](https://wasmbyexample.dev/?programmingLanguage=assemblyscript) I wanted to start building the "High Level Data Structures" section. I then realized how much work it would be to maintain code for passing data between WebAssembly Linear memory would be for each data type, and how much work it would be to created each individual example. Then, my buddy [Ashley Williams](https://twitter.com/ag_dubs) helped me realize, if your docs are becoming too complex, it may be a good idea to write a tool. That way you have less docs to write, and users will have an easier time using your stuff!
 
-Thus, this library was made to help AssemblyScript/JavaScript users build awesome things! I also want to give a huge thanks to the [AssemblyScript team](https://github.com/AssemblyScript/meta) and communitty for the help they provided me. I'm super appreciative of you all! 😄🎉
+Thus, this library was made to help AssemblyScript/JavaScript users build awesome things! I also want to give a huge thanks to the [AssemblyScript team](https://github.com/AssemblyScript/meta) and community for the help they provided me. I'm super appreciative of you all! 😄🎉
 
 ## Performance
 
-**TL;DR** This library should be fast, but depending on your project you may want some more careful consideration. 🤔
+**TL;DR** This library should be pretty darn fast. 🤔
 
-as-bind does all of its data passing at runtime. Meaning this will be slower than a code generated bindings generator, such as something like [wasm-bindgen](https://github.com/rustwasm/wasm-bindgen). This is because, as-bind needs to cycle through every supported type on every paremeter or return value for each function, whenever the function is called. However, this is mitigated due to the Speculative execution that the library implements.
+The transform embeds all the required type information of imported and exported functions into a custom section of the WebAssembly module. All the runtime does is utilize the AssemblyScript Loader to convert these types from JS to ASC and vice-versa. Apart from `Array<T>`, which needs to be handled recursively, the overhead is fairly static and minimal.
 
-Which in this case means, the library by default will assume the type of value being passed to, or returned by a function will not change. Thus, the library will only have to cycle through the params once, cache the types, and then for calls to the functions after this it would be as fast as a code generated solution (in theory). This speculative execution can be turned off as specified in the Reference API.
-
-If your project is doing one-off processing using a high level data type, this project should have a very small impact on performance of your project. However, if you project is doing its processing in a very time constrained loop (such as a game running at 60fps), you may want to be more considerate when choosing this library. The speculative execution should greatly help in the amount of time to pass high level data types, but if your game is already not running as fast as you would like, you may want to avoid this library, or even not using high level data types, for passing memory to your WebAssembly module. However, the library also exposes all original exports under the `AsBindInstance.unboundExports` as covered in the Reference API, so you could, in theory, still access the non-bound exports without any of the performance overhead if you don't require any of the binding / wrapping that AsBind does for you.
-
-Eventually for the most performant option, we would want to do some JavaScript code generation in the AssemblyScript compiler itself, as part of an `as-bindgen` project for the most performant data passing.
-
-In the future, these types of high-level data passing tools will not be needed for WebAssembly toolchains, once the [WebAssembly Inteface Types proposal](https://github.com/WebAssembly/interface-types/blob/master/proposals/interface-types/Explainer.md) lands, and this functionality is handled by the runtime / toolchain.
-
-## Production
-
-`as-bind` works by abstracting away using the [AssemblyScript Loader](https://www.assemblyscript.org/loader.html). For passing values into your AssemblyScript, it uses the Loader on your half to allocate memory, and then passes the pointer to the allocated memory. However, to pass a value back from AssemblyScript to JavaScript, AsBind will iterate through all the supported types until it finds a match (or doesn't in which case it just returns the number). However, returning a value _can sometimes_ conflict with something in AssemblyScript memory, as discovered in [#50](https://github.com/torch2424/as-bind/issues/50).
-
-Thus, for production usage we highly reccomend that you set the [`returnType` property on your bound export functions](#exports) to ensure that this conflict does not happen. 😄
+In the future, these types of high-level data passing tools might not be needed at all, as the [WebAssembly Inteface Types proposal](https://github.com/WebAssembly/interface-types/blob/master/proposals/interface-types/Explainer.md) aims to give WebAssembly an understanding of higher-level types.
 
 ## Projects using as-bind
 
@@ -343,14 +260,6 @@ Thus, for production usage we highly reccomend that you set the [`returnType` pr
 - [use-as-bind](https://github.com/tylervipond/use-as-bind) is a React hook for using as-bind with an as-bind enabled WASM source. It's goal is to provide a simple API for React users to add WASM to their apps. [(Live Demo)](https://tylervipond.github.io/use-as-bind/)
 
 _If you're project is using as-bind, and you would like to be featured here. Please open a README with links to your project, and if appropriate, explaining how as-bind is being used._ 😊
-
-## FAQ and Common Issues
-
-> I am calling my exports, but it is not returning the types that I am returning? It seems to be returning pointers?
-
-This is probably because you are not adding the as-bind entry file. Please see the [Quick Start](#quick-start) on how to compile your AssemblyScript module with this entry file. If this still does not work, please take a look at the [Supported Types](#supported-types) to ensure what type you are trying to pass will work.
-
-_Didn't find a solution to your problem? Feel free to open an issue!_
 
 ## Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "version": "0.6.1",
       "license": "MIT",
+      "dependencies": {
+        "visitor-as": "^0.5.0"
+      },
       "devDependencies": {
         "@assemblyscript/loader": "~0.18.7",
         "@babel/core": "^7.13.10",
@@ -6321,6 +6324,11 @@
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true
     },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -11956,6 +11964,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ts-mixer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-5.4.0.tgz",
+      "integrity": "sha512-Z5u/hpTkP4VWTIQT5vzxyeFAe8siPkatOC0Q49Uf56ccMGSHosI/IEo+t8BFvJX9yiF111YEOKfKY3m72V7F/w=="
+    },
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -12451,6 +12464,15 @@
       "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.4.tgz",
       "integrity": "sha512-/juG65kTL4Cy2su4P8HjtkTxk6VmJDiOPBufWniqQ6wknac6jNiXS9vU+hO3wgusiyqWlzTbVHi0dyJqRONg3w==",
       "dev": true
+    },
+    "node_modules/visitor-as": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/visitor-as/-/visitor-as-0.5.0.tgz",
+      "integrity": "sha512-U2P13pa7BAnfj6IEbP4feS1Rci6NT4GlDcwpqkk90u7LGalc5jH9aMuWnxTC8RJJ92iZzDQ8Lea5/OnLDsgzlw==",
+      "dependencies": {
+        "lodash.clonedeep": "^4.5.0",
+        "ts-mixer": "^5.1.0"
+      }
     },
     "node_modules/which": {
       "version": "1.3.1",
@@ -18127,6 +18149,11 @@
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -22644,6 +22671,11 @@
         "escape-string-regexp": "^1.0.2"
       }
     },
+    "ts-mixer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-5.4.0.tgz",
+      "integrity": "sha512-Z5u/hpTkP4VWTIQT5vzxyeFAe8siPkatOC0Q49Uf56ccMGSHosI/IEo+t8BFvJX9yiF111YEOKfKY3m72V7F/w=="
+    },
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -23062,6 +23094,15 @@
       "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.4.tgz",
       "integrity": "sha512-/juG65kTL4Cy2su4P8HjtkTxk6VmJDiOPBufWniqQ6wknac6jNiXS9vU+hO3wgusiyqWlzTbVHi0dyJqRONg3w==",
       "dev": true
+    },
+    "visitor-as": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/visitor-as/-/visitor-as-0.5.0.tgz",
+      "integrity": "sha512-U2P13pa7BAnfj6IEbP4feS1Rci6NT4GlDcwpqkk90u7LGalc5jH9aMuWnxTC8RJJ92iZzDQ8Lea5/OnLDsgzlw==",
+      "requires": {
+        "lodash.clonedeep": "^4.5.0",
+        "ts-mixer": "^5.1.0"
+      }
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "as-bind",
   "description": "Isomorphic library to handle passing high-level data structures between AssemblyScript and JavaScript 🤝🚀",
   "version": "0.6.1",
-  "main": "dist/as-bind.cjs.js",
+  "main": "dist/transform.cjs.js",
   "module": "dist/as-bind.esm.js",
   "iife": "dist/as-bind.iife.js",
   "types": "dist/as-bind.d.ts",
@@ -110,5 +110,8 @@
   "peerDependencies": {
     "@assemblyscript/loader": "0.18.x",
     "assemblyscript": "0.18.x"
+  },
+  "dependencies": {
+    "visitor-as": "^0.5.0"
   }
 }

--- a/transform.js
+++ b/transform.js
@@ -1,4 +1,4 @@
-import * as assemblyscript from "assemblyscript";
+const { CommonFlags, NodeKind } = require("visitor-as/as");
 
 function isInternalElement(element) {
   return element.internalName.startsWith("~");
@@ -64,22 +64,15 @@ export default class AsBindTransform {
     const flatExportedFunctions = [
       ...this.program.elementsByDeclaration.values()
     ]
-      .filter(el =>
-        elementHasFlag(el, assemblyscript.CommonFlags.MODULE_EXPORT)
-      )
+      .filter(el => elementHasFlag(el, CommonFlags.MODULE_EXPORT))
       .filter(el => !isInternalElement(el))
-      .filter(
-        el =>
-          el.declaration.kind === assemblyscript.NodeKind.FUNCTIONDECLARATION
-      );
+      .filter(el => el.declaration.kind === NodeKind.FUNCTIONDECLARATION);
     const flatImportedFunctions = [
       ...this.program.elementsByDeclaration.values()
     ]
-      .filter(el => elementHasFlag(el, assemblyscript.CommonFlags.DECLARE))
+      .filter(el => elementHasFlag(el, CommonFlags.DECLARE))
       .filter(el => !isInternalElement(el))
-      .filter(
-        v => v.declaration.kind === assemblyscript.NodeKind.FUNCTIONDECLARATION
-      );
+      .filter(v => v.declaration.kind === NodeKind.FUNCTIONDECLARATION);
 
     const typeIds = {};
     const importedFunctions = {};


### PR DESCRIPTION
I took a stab at updating the README for the new as-bind, in an effort to get a beta out for Wasm Summit :D

@torch2424 it does involve quite a bit of deletion as a lot of the properties are gone, but I think that’s a good thing! PTAL and let me know if you have any remarks or concerns!