### PR TITLE
Promise support

### DIFF
--- a/lib/asbind-instance/asbind-instance.js
+++ b/lib/asbind-instance/asbind-instance.js
@@ -142,5 +142,11 @@ export default class AsbindInstance {
         descriptor
       );
     }
+
+    if (!this.isAsyncifyModule) {
+      // If this module wasn’t built with Ayncify, we mock
+      // the asyncify state function to return that we are in “normal” mode.
+      this.exports.asyncify_get_state = () => 0;
+    }
   }
 }

--- a/lib/asbind-instance/asbind-instance.js
+++ b/lib/asbind-instance/asbind-instance.js
@@ -45,6 +45,7 @@ export default class AsbindInstance {
     this.unboundExports = {};
     this.exports = {};
     this.importObject = {};
+    this.asyncifyStorageSize = 8 * 1024;
   }
 
   getTypeId(typeName) {
@@ -62,6 +63,11 @@ export default class AsbindInstance {
   }
 
   _validate() {
+    this.isAsyncifyModule = Boolean(
+      WebAssembly.Module.exports(this.module).find(
+        ({ name }) => name === "asyncify_start_unwind"
+      )
+    );
     if (
       !WebAssembly.Module.exports(this.module).find(exp => exp.name === "__new")
     ) {

--- a/lib/asbind-instance/bind-function.js
+++ b/lib/asbind-instance/bind-function.js
@@ -26,26 +26,92 @@ export function bindImportFunction(
 
   // Create a wrapper function that applies the correct converter function to arguments and
   // return value respectively.
-  return function(...args) {
-    if (args.length != argumentConverterFunctions.length) {
-      throw Error(
-        `Expected ${argumentConverterFunctions.length} arguments, got ${args.length}`
+  if (!asbindInstance.isAsyncifyModule) {
+    return function(...args) {
+      if (args.length != argumentConverterFunctions.length) {
+        throw Error(
+          `Expected ${argumentConverterFunctions.length} arguments, got ${args.length}`
+        );
+      }
+      const newArgs = args.map((v, i) =>
+        argumentConverterFunctions[i](
+          asbindInstance,
+          v,
+          importedFunctionDescriptor.parameters[i]
+        )
       );
-    }
-    const newArgs = args.map((v, i) =>
-      argumentConverterFunctions[i](
+      const result = importedFunction(...newArgs);
+      return returnValueConverterFunction(
         asbindInstance,
-        v,
-        importedFunctionDescriptor.parameters[i]
-      )
-    );
-    const result = importedFunction(...newArgs);
-    return returnValueConverterFunction(
-      asbindInstance,
-      result,
-      importedFunctionDescriptor.returnType
-    );
-  };
+        result,
+        importedFunctionDescriptor.returnType
+      );
+    };
+  } else {
+    return function(...args) {
+      if (
+        asbindInstance.loadedModule.exports.asyncify_get_state() ===
+        2 /* Rewinding */
+      ) {
+        asbindInstance.loadedModule.exports.asyncify_stop_rewind();
+        asbindInstance.loadedModule.exports.__unpin(
+          asbindInstance.asyncifyState.ptr
+        );
+        return returnValueConverterFunction(
+          asbindInstance,
+          asbindInstance.asyncifyState.value,
+          importedFunctionDescriptor.returnType
+        );
+      }
+
+      if (args.length != argumentConverterFunctions.length) {
+        throw Error(
+          `Expected ${argumentConverterFunctions.length} arguments, got ${args.length}`
+        );
+      }
+      const newArgs = args.map((v, i) =>
+        argumentConverterFunctions[i](
+          asbindInstance,
+          v,
+          importedFunctionDescriptor.parameters[i]
+        )
+      );
+      const result = importedFunction(...newArgs);
+      if (!(result instanceof Promise)) {
+        return returnValueConverterFunction(
+          asbindInstance,
+          result,
+          importedFunctionDescriptor.returnType
+        );
+      }
+      asbindInstance.asyncifyState = {
+        ptr: asbindInstance.loadedModule.exports.__new(
+          asbindInstance.asyncifyStorageSize,
+          0
+        )
+      };
+      asbindInstance.loadedModule.exports.__pin(
+        asbindInstance.asyncifyState.ptr
+      );
+      const dv = new DataView(
+        asbindInstance.loadedModule.exports.memory.buffer
+      );
+      dv.setUint32(
+        asbindInstance.asyncifyState.ptr,
+        asbindInstance.asyncifyState.ptr + 8,
+        true
+      );
+      dv.setUint32(
+        asbindInstance.asyncifyState.ptr + 4,
+        asbindInstance.asyncifyState.ptr + 8 * 1024,
+        true
+      );
+      asbindInstance.loadedModule.exports.asyncify_start_unwind(
+        asbindInstance.asyncifyState.ptr
+      );
+      asbindInstance.asyncifyState.promise = result;
+    };
+  }
 }
 
 // Function that takes in an asbind instance, and the key to the export function on the
@@ -65,24 +131,64 @@ export function bindExportFunction(
 
   // Create a wrapper function that applies the correct converter function to arguments and
   // return value respectively.
-  return (...args) => {
-    if (args.length != argumentConverterFunctions.length) {
-      throw Error(
-        `Expected ${argumentConverterFunctions.length} arguments, got ${args.length}`
+  if (!asbindInstance.isAsyncifyModule) {
+    return (...args) => {
+      if (args.length != argumentConverterFunctions.length) {
+        throw Error(
+          `Expected ${argumentConverterFunctions.length} arguments, got ${args.length}`
+        );
+      }
+      const newArgs = args.map((v, i) =>
+        argumentConverterFunctions[i](
+          asbindInstance,
+          v,
+          exportedFunctionDescriptor.parameters[i]
+        )
       );
-    }
-    const newArgs = args.map((v, i) =>
-      argumentConverterFunctions[i](
+      const result = exportedFunction(...newArgs);
+      return returnValueConverterFunction(
         asbindInstance,
-        v,
-        exportedFunctionDescriptor.parameters[i]
-      )
-    );
-    const result = exportedFunction(...newArgs);
-    return returnValueConverterFunction(
-      asbindInstance,
-      result,
-      exportedFunctionDescriptor.returnType
-    );
-  };
+        result,
+        exportedFunctionDescriptor.returnType
+      );
+    };
+  } else {
+    return (...args) => {
+      if (args.length != argumentConverterFunctions.length) {
+        throw Error(
+          `Expected ${argumentConverterFunctions.length} arguments, got ${args.length}`
+        );
+      }
+      const newArgs = args.map((v, i) =>
+        argumentConverterFunctions[i](
+          asbindInstance,
+          v,
+          exportedFunctionDescriptor.parameters[i]
+        )
+      );
+      return function f(...args) {
+        const result = exportedFunction(...args);
+        if (
+          asbindInstance.loadedModule.exports.asyncify_get_state() ===
+          0 /* Normal */
+        ) {
+          return returnValueConverterFunction(
+            asbindInstance,
+            result,
+            exportedFunctionDescriptor.returnType
+          );
+        }
+        asbindInstance.loadedModule.exports.asyncify_stop_unwind();
+        let localAsyncifyState = asbindInstance.asyncifyState;
+        return localAsyncifyState.promise.then(value => {
+          localAsyncifyState.value = value;
+          asbindInstance.asyncifyState = localAsyncifyState;
+          asbindInstance.loadedModule.exports.asyncify_start_rewind(
+            asbindInstance.asyncifyState.ptr
+          );
+          return f(...args);
+        });
+      }.bind(this)(...newArgs);
+    };
+  }
 }

--- a/lib/asbind-instance/bind-function.js
+++ b/lib/asbind-instance/bind-function.js
@@ -74,7 +74,7 @@ export function bindImportFunction(
     );
     dv.setUint32(
       asbindInstance.asyncifyState.ptr + 4,
-      asbindInstance.asyncifyState.ptr + 8 * 1024,
+      asbindInstance.asyncifyState.ptr + asbindInstance.asyncifyStorageSize,
       true
     );
     asbindInstance.loadedModule.exports.asyncify_start_unwind(

--- a/lib/asbind-instance/bind-function.js
+++ b/lib/asbind-instance/bind-function.js
@@ -26,92 +26,62 @@ export function bindImportFunction(
 
   // Create a wrapper function that applies the correct converter function to arguments and
   // return value respectively.
-  if (!asbindInstance.isAsyncifyModule) {
-    return function(...args) {
-      if (args.length != argumentConverterFunctions.length) {
-        throw Error(
-          `Expected ${argumentConverterFunctions.length} arguments, got ${args.length}`
-        );
-      }
-      const newArgs = args.map((v, i) =>
-        argumentConverterFunctions[i](
-          asbindInstance,
-          v,
-          importedFunctionDescriptor.parameters[i]
-        )
+  return function(...args) {
+    if (asbindInstance.exports.asyncify_get_state() === 2 /* Rewinding */) {
+      asbindInstance.loadedModule.exports.asyncify_stop_rewind();
+      asbindInstance.loadedModule.exports.__unpin(
+        asbindInstance.asyncifyState.ptr
       );
-      const result = importedFunction(...newArgs);
+      return returnValueConverterFunction(
+        asbindInstance,
+        asbindInstance.asyncifyState.value,
+        importedFunctionDescriptor.returnType
+      );
+    }
+
+    if (args.length != argumentConverterFunctions.length) {
+      throw Error(
+        `Expected ${argumentConverterFunctions.length} arguments, got ${args.length}`
+      );
+    }
+    const newArgs = args.map((v, i) =>
+      argumentConverterFunctions[i](
+        asbindInstance,
+        v,
+        importedFunctionDescriptor.parameters[i]
+      )
+    );
+    const result = importedFunction(...newArgs);
+    if (!asbindInstance.isAsyncifyModule || !(result instanceof Promise)) {
       return returnValueConverterFunction(
         asbindInstance,
         result,
         importedFunctionDescriptor.returnType
       );
+    }
+    asbindInstance.asyncifyState = {
+      ptr: asbindInstance.loadedModule.exports.__new(
+        asbindInstance.asyncifyStorageSize,
+        0
+      )
     };
-  } else {
-    return function(...args) {
-      if (
-        asbindInstance.loadedModule.exports.asyncify_get_state() ===
-        2 /* Rewinding */
-      ) {
-        asbindInstance.loadedModule.exports.asyncify_stop_rewind();
-        asbindInstance.loadedModule.exports.__unpin(
-          asbindInstance.asyncifyState.ptr
-        );
-        return returnValueConverterFunction(
-          asbindInstance,
-          asbindInstance.asyncifyState.value,
-          importedFunctionDescriptor.returnType
-        );
-      }
-
-      if (args.length != argumentConverterFunctions.length) {
-        throw Error(
-          `Expected ${argumentConverterFunctions.length} arguments, got ${args.length}`
-        );
-      }
-      const newArgs = args.map((v, i) =>
-        argumentConverterFunctions[i](
-          asbindInstance,
-          v,
-          importedFunctionDescriptor.parameters[i]
-        )
-      );
-      const result = importedFunction(...newArgs);
-      if (!(result instanceof Promise)) {
-        return returnValueConverterFunction(
-          asbindInstance,
-          result,
-          importedFunctionDescriptor.returnType
-        );
-      }
-      asbindInstance.asyncifyState = {
-        ptr: asbindInstance.loadedModule.exports.__new(
-          asbindInstance.asyncifyStorageSize,
-          0
-        )
-      };
-      asbindInstance.loadedModule.exports.__pin(
-        asbindInstance.asyncifyState.ptr
-      );
-      const dv = new DataView(
-        asbindInstance.loadedModule.exports.memory.buffer
-      );
-      dv.setUint32(
-        asbindInstance.asyncifyState.ptr,
-        asbindInstance.asyncifyState.ptr + 8,
-        true
-      );
-      dv.setUint32(
-        asbindInstance.asyncifyState.ptr + 4,
-        asbindInstance.asyncifyState.ptr + 8 * 1024,
-        true
-      );
-      asbindInstance.loadedModule.exports.asyncify_start_unwind(
-        asbindInstance.asyncifyState.ptr
-      );
-      asbindInstance.asyncifyState.promise = result;
-    };
-  }
+    asbindInstance.loadedModule.exports.__pin(asbindInstance.asyncifyState.ptr);
+    const dv = new DataView(asbindInstance.loadedModule.exports.memory.buffer);
+    dv.setUint32(
+      asbindInstance.asyncifyState.ptr,
+      asbindInstance.asyncifyState.ptr + 8,
+      true
+    );
+    dv.setUint32(
+      asbindInstance.asyncifyState.ptr + 4,
+      asbindInstance.asyncifyState.ptr + 8 * 1024,
+      true
+    );
+    asbindInstance.loadedModule.exports.asyncify_start_unwind(
+      asbindInstance.asyncifyState.ptr
+    );
+    asbindInstance.asyncifyState.promise = result;
+  };
 }
 
 // Function that takes in an asbind instance, and the key to the export function on the
@@ -131,64 +101,38 @@ export function bindExportFunction(
 
   // Create a wrapper function that applies the correct converter function to arguments and
   // return value respectively.
-  if (!asbindInstance.isAsyncifyModule) {
-    return (...args) => {
-      if (args.length != argumentConverterFunctions.length) {
-        throw Error(
-          `Expected ${argumentConverterFunctions.length} arguments, got ${args.length}`
-        );
-      }
-      const newArgs = args.map((v, i) =>
-        argumentConverterFunctions[i](
-          asbindInstance,
-          v,
-          exportedFunctionDescriptor.parameters[i]
-        )
+  return (...args) => {
+    if (args.length != argumentConverterFunctions.length) {
+      throw Error(
+        `Expected ${argumentConverterFunctions.length} arguments, got ${args.length}`
       );
-      const result = exportedFunction(...newArgs);
-      return returnValueConverterFunction(
+    }
+    const newArgs = args.map((v, i) =>
+      argumentConverterFunctions[i](
         asbindInstance,
-        result,
-        exportedFunctionDescriptor.returnType
-      );
-    };
-  } else {
-    return (...args) => {
-      if (args.length != argumentConverterFunctions.length) {
-        throw Error(
-          `Expected ${argumentConverterFunctions.length} arguments, got ${args.length}`
+        v,
+        exportedFunctionDescriptor.parameters[i]
+      )
+    );
+    return function f(...args) {
+      const result = exportedFunction(...args);
+      if (asbindInstance.exports.asyncify_get_state() === 0 /* Normal */) {
+        return returnValueConverterFunction(
+          asbindInstance,
+          result,
+          exportedFunctionDescriptor.returnType
         );
       }
-      const newArgs = args.map((v, i) =>
-        argumentConverterFunctions[i](
-          asbindInstance,
-          v,
-          exportedFunctionDescriptor.parameters[i]
-        )
-      );
-      return function f(...args) {
-        const result = exportedFunction(...args);
-        if (
-          asbindInstance.loadedModule.exports.asyncify_get_state() ===
-          0 /* Normal */
-        ) {
-          return returnValueConverterFunction(
-            asbindInstance,
-            result,
-            exportedFunctionDescriptor.returnType
-          );
-        }
-        asbindInstance.loadedModule.exports.asyncify_stop_unwind();
-        let localAsyncifyState = asbindInstance.asyncifyState;
-        return localAsyncifyState.promise.then(value => {
-          localAsyncifyState.value = value;
-          asbindInstance.asyncifyState = localAsyncifyState;
-          asbindInstance.loadedModule.exports.asyncify_start_rewind(
-            asbindInstance.asyncifyState.ptr
-          );
-          return f(...args);
-        });
-      }.bind(this)(...newArgs);
-    };
-  }
+      asbindInstance.loadedModule.exports.asyncify_stop_unwind();
+      let localAsyncifyState = asbindInstance.asyncifyState;
+      return localAsyncifyState.promise.then(value => {
+        localAsyncifyState.value = value;
+        asbindInstance.asyncifyState = localAsyncifyState;
+        asbindInstance.loadedModule.exports.asyncify_start_rewind(
+          asbindInstance.asyncifyState.ptr
+        );
+        return f(...args);
+      });
+    }.bind(this)(...newArgs);
+  };
 }

--- a/test/test-runner.js
+++ b/test/test-runner.js
@@ -1,5 +1,6 @@
 const { promisify } = require("util");
 const fs = require("fs/promises");
+const path = require("path");
 
 const Express = require("express");
 const Mocha = require("mocha");
@@ -32,7 +33,7 @@ async function compileAllAsc() {
   const transformFile = require.resolve("../dist/transform.cjs.js");
   for (const ascFile of ascFiles) {
     console.log(`Compiling ${ascFile}...`);
-    await asc.main([
+    const params = [
       "--runtime",
       "stub",
       "--exportRuntime",
@@ -41,7 +42,13 @@ async function compileAllAsc() {
       "--binaryFile",
       ascFile.replace(/\.ts$/, ".wasm"),
       ascFile
-    ]);
+    ];
+    try {
+      const configFile = "./" + path.join(path.dirname(ascFile), "config.js");
+      const config = require(configFile);
+      await config?.params?.(params);
+    } catch (e) {}
+    await asc.main(params);
   }
 }
 

--- a/test/tests/string-promise/asc.ts
+++ b/test/tests/string-promise/asc.ts
@@ -1,0 +1,5 @@
+export function swapAndPad(a: string, b: string): string {
+  return "!" + swappedConcat(a, b) + "!";
+}
+
+declare function swappedConcat(a: string, b: string): string;

--- a/test/tests/string-promise/config.js
+++ b/test/tests/string-promise/config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  params(param) {
+    param.push("--runPasses", "asyncify");
+  }
+};

--- a/test/tests/string-promise/test.js
+++ b/test/tests/string-promise/test.js
@@ -1,0 +1,12 @@
+describe("as-bind", function() {
+  it("should handle strings", async function() {
+    const instance = await AsBind.instantiate(this.rawModule, {
+      asc: {
+        async swappedConcat(a, b) {
+          return b + a;
+        }
+      }
+    });
+    assert((await instance.exports.swapAndPad("a", "b")) === "!ba!");
+  });
+});


### PR DESCRIPTION
I’m publishing this Draft PR so folks can experiment with this. @torch2424 I’d love to hear what you think about this in general. I’m sure the code needs some cleaning up, but I’m pretty excited about having Web API Integration work almost out-of-the-box.

---

This PR gives as-bind the ability to handle async functions & promises in imported functions. This allows AssemblyScript modules to integrate with asynchronous web APIs like `fetch()`, idb, `createImageBitmap`, WebUSB, WebBluetooth, etc. You name it!

## Example

```ts
// main. ts
declare function fetch(s: string): ArrayBuffer;
declare function log(s: string): void;

export function run(): void {
  const buffer = fetch("/package.json"); // ⬅️ 🎉🎉🎉🎉
 
  // Quick ad-hoc string decoding
  const chars = Uint8Array.wrap(buffer);
  let str = "";
  for (let i = 0; i < chars.length; i++) {
    str += String.fromCharCode(chars[i]);
  }
  log(str);
}
```

```js
import { instantiate } from "as-bind";

import wasmUrl from "asc:./main.ts";

const instance = await instantiate(fetch(wasmUrl), {
  main: {
    log: (v) => (document.all.log.innerHTML += v + "\n"),
    // This returns a Promise<ArrayBuffer>. as-bind utilizes asyncify
    // to make the result appear synchronous to AS.
    fetch: (v) => fetch(v).then((r) => r.arrayBuffer()),
  },
});
instance.exports.run();
```

<details>
<summary>Screenshot</summary>

<img width="397" alt="Screenshot 2021-04-28 at 18 30 34" src="https://user-images.githubusercontent.com/234957/116447418-e272f700-a84f-11eb-8dee-4eea8b603ef9.png">

</details>

Here’s a [gist] with a working build system.

(In the future, you could even use `externref` to hand `Response, allowing you to import `fetch()` directly.)

## How to use it

The heavy lifting is done under the hood by [Asyncify]. All you need to do is add `--runPasses="asyncify"` to your `asc` invocation, all the rest happens inside as-bind automatically. 

If you want to play around with this, here are step-by-step instructions:

1. Clone this repo and check out this branch `promise-support`
2. run `npm install && npm run build`
2. Clone the [gist] to somewhere else (or take any project that uses as-bind v0.7+)
3. Run `npm link /path/to/as-bind/clone/from/step/1`
4. Add `--runPasses="asyncify"` to your `asc` invocation
5. ???
6. Profit!

## How does it work

WebAssembly is synchronous, and functions that are imported by your Wasm from the host environent (i.e. from JS) are expected to return their value synchronously. But the web is asynchronous. Making something synchronous look asynchronous is easy, but the other way is near impossible.

[Asyncify](https://web.dev/asyncify/) is a tool (more specifically: a binaryen pass) that effectively allows you to “pause” WebAssembly. Through this, you can make make JS that’s asynchronous _look_ synchronous to WebAssembly. The trick is to pause Wasm when an imported function returns a promise, wait until the promise has resolved and then unpause to continue with the resolved value. From the perspective of WebAssembly, it’s as if the pause never happened.

To facilitate the pausing and later resuming, Asyncify stores the current stack of the Wasm VM to memory. To avoid any corruption, as-bind allocates a block of memory via the runtime and prevents it from getting GC’d. How much memory is actually needed, depends on the number of function parameters and function calls you have on your stack. By default, as-bind reserves 8KiB per paused Wasm call. If you to change that number, add this just after instantiation: `instance.asyncifyStorageSize = 8 * 1024;`.

## What does it _not_ do

This does not add support for `async`/`await` to AssemblyScript itself, nor is it a full integration of AS into JavaScript’s event loop.

## Noteworthy limitations

Asyncify has a small performance and binary size impact. I have not seen it become a problem, but it’s something to be aware of. Because Asyncify rewrites your Wasm binary, it will probably break source maps. Also, [Asyncify currently can’t handle `externref` et al](https://github.com/WebAssembly/binaryen/issues/3739).

[gist]: https://gist.github.com/surma/854fc261cf6c664f2dc32c5078065068