### PR TITLE
feat: add namespace exported declare function support #91 and fix #94

### DIFF
--- a/lib/asbind-instance/type-converters.js
+++ b/lib/asbind-instance/type-converters.js
@@ -134,11 +134,11 @@ export const converters = new Map([
   ],
   [
     "~lib/typedarray/Float32Array",
-    { ascToJs: getArrayBuffer, jsToAsc: putArrayBufferView }
+    { ascToJs: getArrayBufferView, jsToAsc: putArrayBufferView }
   ],
   [
     "~lib/typedarray/Float64Array",
-    { ascToJs: getArrayBuffer, jsToAsc: putArrayBufferView }
+    { ascToJs: getArrayBufferView, jsToAsc: putArrayBufferView }
   ],
   [
     "~lib/arraybuffer/ArrayBuffer",

--- a/test/tests/arraybufferview/asc.ts
+++ b/test/tests/arraybufferview/asc.ts
@@ -7,4 +7,11 @@ export function swapAndPad(a: Uint8Array, b: Uint8Array): Uint8Array {
   return result;
 }
 
+export function testFloat32Array(): void {
+  const data = new Float32Array(1);
+  data[0] = <f32>0.5;
+  testF32Arr(data);
+}
+
 declare function swappedConcat(a: Uint8Array, b: Uint8Array): Uint8Array;
+declare function testF32Arr(data: Float32Array): void;

--- a/test/tests/arraybufferview/test.js
+++ b/test/tests/arraybufferview/test.js
@@ -1,5 +1,5 @@
 describe("as-bind", function() {
-  it("should handle Uint8Arrays", async function() {
+  it("should handle Uint8Arrays and Float32Array", async function() {
     const instance = await AsBind.instantiate(this.rawModule, {
       asc: {
         swappedConcat(a, b) {
@@ -7,6 +7,10 @@ describe("as-bind", function() {
           result.set(b, 0);
           result.set(a, b.length);
           return result;
+        },
+        testF32Arr(data) {
+          assert(data instanceof Float32Array);
+          assert(data[0] == 0.5);
         }
       }
     });

--- a/test/tests/namespace/asc.ts
+++ b/test/tests/namespace/asc.ts
@@ -1,0 +1,7 @@
+namespace console {
+  export declare function log(str: string): void;
+}
+
+export function fn(): void {
+  console.log("ok");
+}

--- a/test/tests/namespace/test.js
+++ b/test/tests/namespace/test.js
@@ -1,0 +1,12 @@
+describe("as-bind", function() {
+  it("should support exported declare function in namespace", async function() {
+    const instance = await AsBind.instantiate(this.rawModule, {
+      asc: {
+        "console.log"(str) {
+          assert(str === "ok");
+        }
+      }
+    });
+    instance.exports.fn();
+  });
+});


### PR DESCRIPTION
add type annotation and namespace exported declare function support #91 and fix #94

```ts
/** @type {asc.Program} */
const program = this.program;
```

```
=== Browser results
✓ as-bind should handle array
✓ as-bind should handle nested array
✓ as-bind should handle ArrayBuffers
✓ as-bind should handle Uint8Arrays
✓ as-bind should be extensible with custom type handlers
✓ as-bind should handle the prototype chain on the imports object
✓ as-bind works synchronously
✓ as-bind should handle multiple files correctly
✓ as-bind should support exported declare function in namespace
✓ as-bind should not GC strings
✓ as-bind should handle strings
✓ as-bind should handle unexpected imports gracefully
✓ as-bind should handle unknown types gracefully
✓ as-bind should handle unused imported functions gracefully
```