### PR TITLE
Fixed Markdown Demo Building: Added the correct Transform file

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "md:wasm:watch": "chokidar --initial \"examples/markdown-parser/assembly/**/*\" -c \"run-s md:wasm:build\"",
     "md:ts:watch": "chokidar --initial \"examples/markdown-parser/assembly/**/*\" -c \"run-s md:ts:build\"",
     "md:js:watch": "chokidar --initial \"examples/markdown-parser/**/*\" -c \"rollup -c --environment MD,DEV\"",
-    "md:wasm:build": "asc examples/markdown-parser/assembly/index.ts --transform ./transform.js -b dist/examples/markdown-parser/index.wasm -t dist/examples/markdown-parser/index.wat --sourceMap dist/examples/markdown-parser/index.wasm.map --runtime incremental --exportRuntime",
+    "md:wasm:build": "asc examples/markdown-parser/assembly/index.ts --transform ./dist/transform.cjs.js -b dist/examples/markdown-parser/index.wasm -t dist/examples/markdown-parser/index.wat --sourceMap dist/examples/markdown-parser/index.wasm.map --runtime incremental --exportRuntime",
     "md:ts:build": "tsc --project examples/markdown-parser/assembly/ --outDir dist/ts/ --module \"es2015\"",
     "md:js:build": "rollup -c --environment MD,PROD",
     "md:deploy": "run-s build md:build md:deploy:gh-pages",


### PR DESCRIPTION
A super small bug, should allow us to deploy the markdown demo when we release new versions again 😄 

# Example

```
torch2424 at torch2424-XPS-13-7390 in ~/Source/as-bind on torch2424/fix-markdown-parser▲
$ npm run md:build

> as-bind@0.8.2 md:build
> run-s md:wasm:build md:ts:build md:js:build


> as-bind@0.8.2 md:wasm:build
> asc examples/markdown-parser/assembly/index.ts --transform ./dist/transform.cjs.js -b dist/examples/markdown-parser/index.wasm -t dist/examples/markdown-parser/index.wat --sourceMap dist/examples/markdown-parser/index.wasm.map --runtime incremental --exportRuntime


> as-bind@0.8.2 md:ts:build
> tsc --project examples/markdown-parser/assembly/ --outDir dist/ts/ --module "es2015"


> as-bind@0.8.2 md:js:build
> rollup -c --environment MD,PROD


examples/markdown-parser/index.js → dist/examples/markdown-parser/index.iife.js...
Created bundle index.iife.js: 35.28 kB → 11.31 kB (gzip)
created dist/examples/markdown-parser/index.iife.js in 3.5s
torch2424 at torch2424-XPS-13-7390 in ~/Source/as-bind on torch2424/fix-markdown-parser▲
```